### PR TITLE
keep del when del-set-sequence exist, update the ut

### DIFF
--- a/tests/redis_state_ut.cpp
+++ b/tests/redis_state_ut.cpp
@@ -344,9 +344,16 @@ TEST(ConsumerStateTable, set_del_set)
         KeyOpFieldsValuesTuple kco;
         c.pop(kco);
         EXPECT_EQ(kfvKey(kco), key);
-        EXPECT_EQ(kfvOp(kco), "SET");
+        EXPECT_EQ(kfvOp(kco), "DEL");
 
         auto fvs = kfvFieldsValues(kco);
+        EXPECT_EQ(fvs.size(), 0U);
+
+        c.pop(kco);
+        EXPECT_EQ(kfvKey(kco), key);
+        EXPECT_EQ(kfvOp(kco), "SET");
+
+        fvs = kfvFieldsValues(kco);
         EXPECT_EQ(fvs.size(), (unsigned int)maxNumOfFields);
 
         map<string, string> mm;


### PR DESCRIPTION
what I did:  
    when del-set-sequence exist in consumer table, I keep the del event been execute even a set of the same key is already seen after the del.
why I did:
    in the old code, the del is setting an key without fv, so if a set with fv after, it will only execute a set, so the multimap m_toSync can not  seen the del event, sometimes the lost del may result errors if something is depending on the del event.